### PR TITLE
fixed incorrect argument name

### DIFF
--- a/R/project_cycle_space.R
+++ b/R/project_cycle_space.R
@@ -110,7 +110,7 @@ NULL
 #' @importMethodsFrom AnnotationDbi colnames get ncol nrow
 .humanSymbol <- function(gname, AnnotationDb = NULL) {
     AnnotationDb <- .getAnnotationDB(AnnotationDb, species = "human")
-    SYMBOL <- AnnotationDbi::mapIds(AnnotationDb, keys = gname, columns = "SYMBOL", keytype = "ENSEMBL", multiVals = "first")
+    SYMBOL <- AnnotationDbi::mapIds(AnnotationDb, keys = gname, column = "SYMBOL", keytype = "ENSEMBL", multiVals = "first")
     return(SYMBOL)
 }
 


### PR DESCRIPTION
I got an error when running project_cycle_space() with gname.type = "ENSEMBL" and  species = "human" that is resolved by changing the argument name